### PR TITLE
Add ImageBench to evaluation frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ _Support ongoing maintenance and curation via [GitHub Sponsors](https://github.c
 - [Arize Phoenix](https://github.com/Arize-ai/phoenix) – Open-source toolkit for LLM/RAG evals and trace analysis.
 - [LightEval](https://github.com/hazyresearch/lighteval) – Fast LLM evaluation pipeline.
 - [Evalchemy](https://github.com/zphang/evalchemy) – Lightweight framework for running LLM benchmarks.
+- [ImageBench](https://imagebench.ai) – Public benchmark site for text-to-image models, publishing side-by-side prompt results, comparison pages, and evaluation methodology.
 - [Weights & Biases Evaluation](https://wandb.ai) – Model comparison and metric visualization tools.
 
 ## Datasets


### PR DESCRIPTION
Adds ImageBench as a small evaluation resource entry under `Evaluation Frameworks`.

Reason for inclusion:
- public benchmark site for text-to-image models
- side-by-side prompt results and comparison pages
- methodology content describing the evaluation surface

Kept the change minimal and followed the existing README format.

Happy to revise wording or category placement if needed.