### PR TITLE
Add DocuBench (document extraction benchmark)

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ _Support ongoing maintenance and curation via [GitHub Sponsors](https://github.c
 - [ImageNet](https://image-net.org/) – Core image classification benchmark still used for comparison.
 - [LAION Benchmarks](https://laion.ai/blog/) – Evaluation datasets for multimodal embeddings and retrieval.
 - [Video Question Answering Benchmarks](https://github.com/topics/video-question-answering) – For video–text reasoning.
+- [DocuBench](https://github.com/DocuPipe/DocuBench) – Document data extraction benchmark: 50 hard real-world documents, hand-verified labels, and an open scorer.
   
 ## RAG Benchmarks
 


### PR DESCRIPTION
This adds DocuBench to the Multimodal Benchmarks section.

DocuBench is an open benchmark for schema-guided structured extraction: 50 hard real-world documents across 10 file types and 11 languages (including Hebrew, Arabic, Japanese, and Chinese), each paired with a JSON Schema and a hand-verified JSON label. The repo includes a standalone scorer (macro-average field accuracy with order-independent array matching), committed raw outputs from six baseline systems, and an interactive per-document results explorer.

Disclosure: I'm a cofounder of DocuPipe, which built and maintains the benchmark. Every system including ours is scored by the same public scorer against the same labels, and all raw outputs are committed, so the results table is reproducible by running the scorer.

https://github.com/DocuPipe/DocuBench
