### PR TITLE
Add doceval to Evaluation Frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ _Support ongoing maintenance and curation via [GitHub Sponsors](https://github.c
 - [LightEval](https://github.com/hazyresearch/lighteval) – Fast LLM evaluation pipeline.
 - [Evalchemy](https://github.com/zphang/evalchemy) – Lightweight framework for running LLM benchmarks.
 - [Weights & Biases Evaluation](https://wandb.ai) – Model comparison and metric visualization tools.
+- [doceval](https://github.com/dave8172/doceval) – Eval harness for LLM document-extraction pipelines: field-level accuracy, failure-mode taxonomy, and cost tracking.
 
 ## Datasets
 


### PR DESCRIPTION
Adds doceval to the Evaluation Frameworks section.

doceval is an open-source eval harness for LLM-based document extraction pipelines. Point it at any extractor function (Claude, GPT, regex, rules) and a labeled dataset — it returns field-level accuracy, a failure-mode taxonomy (missed field / wrong value / wrong format), and optional per-document cost tracking.

Disclosure: I'm the author.

https://github.com/dave8172/doceval