### PR TITLE
Add RHOB (Reward Hacking Onset Benchmark) to Safety & Robustness

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ _Support ongoing maintenance and curation via [GitHub Sponsors](https://github.c
 - [Red Team Prompt Datasets](https://github.com/topics/jailbreak-prompts) – Collections of prompts to stress-test model alignment.
 - [RobustBench](https://github.com/RobustBench/robustbench) – Leaderboard of robust classification models.
 - [AdversarialNLI](https://github.com/facebookresearch/anli) – Dataset for robustness in natural language inference.
+- [RHOB (Reward Hacking Onset Benchmark)](https://github.com/Aarav500/rhob) – Matched-proxy environment benchmark across 14 reward-hacking mechanisms with a 30-detector suite and cross-family transfer analysis.
 
 ## Evaluation Frameworks
 


### PR DESCRIPTION
Split from #18 per maintainer request — one resource per PR. Adds RHOB: a matched-proxy environment benchmark across 14 reward-hacking mechanisms with a 30-detector suite and cross-family transfer analysis. https://github.com/Aarav500/rhob (MIT).