### PR TITLE
Add StructEval to evaluation frameworks

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,6 +74,7 @@ _Support ongoing maintenance and curation via [GitHub Sponsors](https://github.c
 - [LightEval](https://github.com/hazyresearch/lighteval) – Fast LLM evaluation pipeline.
 - [Evalchemy](https://github.com/zphang/evalchemy) – Lightweight framework for running LLM benchmarks.
 - [Weights & Biases Evaluation](https://wandb.ai) – Model comparison and metric visualization tools.
+- [StructEval](https://github.com/TIGER-AI-Lab/StructEval) – Benchmark and evaluation framework for structured-output generation and cross-format conversion, with syntax, structural, and visual checks across text and renderable formats.
 - [ClawBench](https://github.com/TIGER-AI-Lab/ClawBench) - Open framework for benchmarking AI web agents on real-world web tasks.
 
 ## Datasets


### PR DESCRIPTION
## Summary

- add StructEval to the Evaluation Frameworks section
- link the official repository for verification
- describe its structured-output generation and cross-format evaluation coverage

StructEval is a documented TMLR 2025 benchmark/framework with an open-source implementation and a clear fit for this list’s evaluation-framework scope.